### PR TITLE
Support Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,14 @@ DEBUG ?=
 # Use a fake camera implementation for testing (if set).
 BAMBU_FAKE ?=
 
+USER_CONFIG_DIR ?= $(HOME)/.config
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	USER_CONFIG_DIR := '$(HOME)/Library/Application Support'
+endif
 # Path to the Bambu Studio plugin directory. Assumes it is installed and ran at
 # least once to download the expected plugins.
-PLUGIN_PATH ?= $(HOME)/.config/BambuStudio/plugins
+PLUGIN_PATH := $(USER_CONFIG_DIR)/BambuStudio/plugins
 
 # Which server implementation to use, including:
 # - HTTP: Multipart JPEG stream using microhttpd

--- a/Makefile
+++ b/Makefile
@@ -22,27 +22,29 @@ ifdef DEBUG
 CFLAGS := -g -DDEBUG
 endif
 
-LDFLAGS := \
-	-L$(PLUGIN_PATH) \
-	-Wl,-rpath=$(PLUGIN_PATH) \
-
 LDLIBS := -lpthread
 
 OBJECTS :=
 
 ifdef BAMBU_FAKE
-	LDLIBS  += -ljpeg
+	CFLAGS += $(shell pkg-config --cflags libjpeg)
+	LDLIBS  += $(shell pkg-config --libs libjpeg)
 	OBJECTS += bambu_fake.o
 else
+	LDFLAGS := \
+		-L$(PLUGIN_PATH) \
+		-Wl,-rpath,$(PLUGIN_PATH)
 	LDLIBS  += -lBambuSource
 	OBJECTS += bambu.o
 endif
 
 ifeq ($(SERVER), HTTP)
-	LDLIBS  += -lmicrohttpd
+	CFLAGS += $(shell pkg-config --cflags libmicrohttpd)
+	LDLIBS  += $(shell pkg-config --libs libmicrohttpd)
 	OBJECTS += server_microhttpd.o
 else
-	LDLIBS  += -lavcodec -lavformat -lavutil
+	CFLAGS += $(shell pkg-config --cflags libavcodec libavformat libavutil)
+	LDLIBS  += $(shell pkg-config --libs libavcodec libavformat libavutil)
 	OBJECTS += server_ffmpeg_rtp.o
 endif
 

--- a/server_microhttpd.c
+++ b/server_microhttpd.c
@@ -275,7 +275,10 @@ int server_start(server_ctx_t ctx,
   }
 
   enum MHD_FLAG flags = MHD_NO_FLAG;
-  flags |= MHD_USE_EPOLL_INTERNAL_THREAD;
+  // Not supported on Darwin? Maybe use poll or just not bother?
+  // flags |= MHD_USE_EPOLL_INTERNAL_THREAD;
+  // I assume there's some synchronization expectation that we want this. Looks like the API changed so it's not per polling method.
+  flags |= MHD_USE_INTERNAL_POLLING_THREAD;
   flags |= MHD_ALLOW_SUSPEND_RESUME;
   flags |= MHD_USE_ERROR_LOG;
 #ifdef DEBUG


### PR DESCRIPTION
I made a few tweaks to support Darwin/macOS. I made as few tweaks as possible but ensured that Linux and macOS usage would be similar, and kept the flavour of your Makefile. I think if it still works for you on Linux (specifically removing the epoll flag, and using pkg-config) then I think it's an easy win.

Thanks for the cool little project.