### PR TITLE
Added docker support for bambucam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 /bambucam
 .env
+*.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 /bambucam
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV DEVICE_IP="printer-ip"
+ENV DEVICE_ID="printer-serial-number"
+ENV ACCESS_CODE="printer-access-code"
+ENV PORT=1234
+
+WORKDIR /app
+
+RUN mkdir plugins
+
+# copy the executable and plugins
+COPY ./bambucam .
+COPY ./plugins ./plugins
+
+# set plugin path
+ENV PLUGIN_PATH=/app/plugins
+
+EXPOSE ${PORT}
+ENTRYPOINT ["./bambucam"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEVICE_IP="printer-ip"
 ENV DEVICE_ID="printer-serial-number"
 ENV ACCESS_CODE="printer-access-code"
-ENV PORT=1234
+ENV PORT=8082
+
+# true = retry to reach printer if its offline, false = shutdown
+ENV KEEP_ALIVE=true
+
+# the interval (seconds) the printer is checked until available
+ENV PING_INTERVAL=10
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libmicrohttpd12 \
+    libjpeg62-turbo \
+    netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -19,4 +31,8 @@ COPY ./plugins ./plugins
 ENV PLUGIN_PATH=/app/plugins
 
 EXPOSE ${PORT}
-ENTRYPOINT ["./bambucam"]
+
+
+COPY start.sh .
+RUN chmod +x start.sh
+ENTRYPOINT ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ services:
       - "8082:8082" # the port number mapping where the video stream is serviced
 
     environment:
-    - DEVICE_IP: "192.168.168.172" # your printers ip
+    - DEVICE_IP="192.168.1.123" # your printers ip
     - DEVICE_ID="1A2B3C12345678" # your printer serial number (tho check if its the right device)
     - ACCESS_CODE="12345678" # your printer access code
     - PORT=8082 # the port number where the video stream should be serviced

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ services:
 
     restart: no
 ````
+
+## Building the Image
+If you want to build the docker image for yourself, follow those steps:
+- clone this repo
+- create a folder "plugins"
+- put your "libBambuStudio.so" in there which is made available by Bambulab Software
+- follow the building steps of jtessler´s repo (building the bambucam executeable in the repo root directory)
+- build using the Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Bambu Cam
 =========
+Disclaimer: If you like the docker functionality and give this project a star, please consider checking out jtessler´s repo who made this possible creating this cli-tool.
 
 A simple wrapper around [Bambu Studio]'s `libBambuSource.so` prebuilt to access
 the camera frames from a 3D printer in LAN mode and, encode it, and serve a

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bambu Cam
 > [!NOTE]
 > If you like the docker functionality and give this project a star, please consider also checking out jtessler´s repo who made this possible creating this cli-tool.
 
-This repo contains the containerized version of jtessler´s BambuCam command-line tool which allowes setting up a webserver which streams the cam of Bamublab-Printers.
+This repo contains the containerized version of jtessler´s BambuCam command-line tool which allowes setting up a webserver which streams the cam of Bambulab-Printers.
 
 ## Docker Usage
 Use the following docker-compose.yaml to spawn a video-server:
@@ -18,10 +18,11 @@ services:
     ports:
       - "8082:8082" # the port number mapping where the video stream is serviced
 
-    environment: 
-    - DEVICE_ID="1A2B3C12345678" # your printer serial number (tho check for the right device)
+    environment:
+    - DEVICE_IP: "192.168.168.172" # your printers ip
+    - DEVICE_ID="1A2B3C12345678" # your printer serial number (tho check if its the right device)
     - ACCESS_CODE="12345678" # your printer access code
-    - PORT=8082 # the port number where the video stream is serviced
+    - PORT=8082 # the port number where the video stream should be serviced
     - KEEP_ALIVE=true # true = run infinitly retrying if printer is offline, false = shutdown if printer offline
     - PING_INTERVAL=10 # the interval (seconds) the printer is checked until available
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,9 @@
 Bambu Cam
 =========
-Disclaimer: If you like the docker functionality and give this project a star, please consider checking out jtessler´s repo who made this possible creating this cli-tool.
+> [!NOTE]
+> If you like the docker functionality and give this project a star, please consider also checking out jtessler´s repo who made this possible creating this cli-tool.
 
-A simple wrapper around [Bambu Studio]'s `libBambuSource.so` prebuilt to access
-the camera frames from a 3D printer in LAN mode and, encode it, and serve a
-video stream at a given port.
-
-Usage:
-
-```
-$ bambucam <device-ip> <device-id> <passcode> <port>
-```
-
-Where:
-
-- `<device-ip>`: Bambu printer local IP, e.g. `192.168.0.200`
-- `<device-id>`: Bambu printer ID (serial number), e.g. `0123456789ABCDE`
-- `<passcode>`: Bambu printer LAN mode pass code, e.g. `12345678`
-- `<port>`: Port on which to serve the video stream
-
-Bambu Cam supports multiple video stream types depending on the `SERVER` build
-flag. The supported video stream types are:
-
-- `HTTP`: Multipart JPEG stream using microhttpd
-- `RTP`: RTP video stream using FFmpeg
+This repo contains the containerized version of jtessler´s BambuCam command-line tool which allowes setting up a webserver which streams the cam of Bamublab-Printers.
 
 ## Docker Usage
 Use the following docker-compose.yaml to spawn a video-server:
@@ -47,92 +27,3 @@ services:
 
     restart: no
 ````
-
-## Build instructions
-
-Prepare the necessary `ffmpeg` and `libmicrohttpd` dependencies:
-
-```
-$ sudo apt install \
-    libavcodec-dev \
-    libavformat-dev \
-    libavutil-dev \
-    libjpeg-dev \
-    libmicrohttpd-dev
-```
-
-Assumes you have [Bambu Studio] installed and ran at least once to download the
-expected plugins.
-
-```
-$ make -j
-```
-
-Use `PLUGIN_PATH` to specify a different path if the plugins are installed in a
-directory other than the default `~/.config/BambuStudio/plugins`.
-
-```
-$ make PLUGIN_PATH=/path/to/bambu/plugins -j
-```
-
-Use `DEBUG` to add more verbose logging and build debug symbols.
-
-```
-$ make DEBUG=1 -j
-```
-
-Use `BAMBU_FAKE` to use a fake camera implementation to test without an actual
-printer hardware. All device arguments are obviously ignored in this mode.
-
-```
-$ make BAMBU_FAKE=1 -j
-```
-
-Use `SERVER` to select the video streaming server implementation. More details
-below.
-
-```
-$ make SERVER=RTP -j
-```
-
-## HTTP Stream Details
-
-```
-$ make SERVER=HTTP -j
-```
-
-The HTTP server uses [`multipart/x-mixed-replace`] to continuous send JPEG files
-in a never-ending response.
-
-Build Bambu Cam with `SERVER=HTTP` and you can view the video stream on any web
-browser by navigating to `http://localhost:<port>/`.
-
-![Video stream example in a web browser](https://i.imgur.com/hvHuyc6.png])
-
-[`multipart/x-mixed-replace`]:https://wiki.tcl-lang.org/page/multipart%2Fx-mixed-replace
-
-## RTP Stream Details
-
-```
-$ make SERVER=RTP -j
-```
-
-The RTP stream uses the Pro-MPEG Code of Practice #3 Release 2 FEC protocol,
-which is "a 2D parity-check forward error correction mechanism for MPEG-2
-Transport Streams sent over RTP." Read more about the protocol in the [FFmpeg]
-and [Wireshark] documention.
-
-VLC supports this protocol and explains why we can use the `rtp://` path
-without serving any SDP nor RTSP information.
-
-Build Bambu Cam with `SERVER=RTP` and you can view the RTP stream in VLC:
-
-```
-$ vlc rtp://localhost/<port>
-```
-
-![Video stream example in VLC](https://i.imgur.com/lOo64MV.png)
-
-[Bambu Studio]:https://bambulab.com/en/download/studio
-[FFmpeg]:https://ffmpeg.org/ffmpeg-protocols.html#prompeg
-[Wireshark]:https://wiki.wireshark.org/2dParityFEC

--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 Bambu Cam
 =========
-> [!NOTE]
-> If you like the docker functionality and give this project a star, please consider also checking out jtessler´s repo who made this possible creating this cli-tool.
 
-This repo contains the containerized version of jtessler´s BambuCam command-line tool which allowes setting up a webserver which streams the cam of Bambulab-Printers.
+A simple wrapper around [Bambu Studio]'s `libBambuSource.so` prebuilt to access
+the camera frames from a 3D printer in LAN mode and, encode it, and serve a
+video stream at a given port.
+
+Usage:
+
+```
+$ bambucam <device-ip> <device-id> <passcode> <port>
+```
+
+Where:
+
+- `<device-ip>`: Bambu printer local IP, e.g. `192.168.0.200`
+- `<device-id>`: Bambu printer ID (serial number), e.g. `0123456789ABCDE`
+- `<passcode>`: Bambu printer LAN mode pass code, e.g. `12345678`
+- `<port>`: Port on which to serve the video stream
+
+Bambu Cam supports multiple video stream types depending on the `SERVER` build
+flag. The supported video stream types are:
+
+- `HTTP`: Multipart JPEG stream using microhttpd
+- `RTP`: RTP video stream using FFmpeg
 
 ## Docker Usage
 Use the following docker-compose.yaml to spawn a video-server:
@@ -36,3 +55,92 @@ If you want to build the docker image by yourself, follow those steps:
 - put your "libBambuStudio.so" in there which is made available by Bambulab Software
 - follow the building steps of jtessler´s repo (building the bambucam executeable in the repo root directory)
 - build using the Dockerfile
+
+## Build instructions
+
+Prepare the necessary `ffmpeg` and `libmicrohttpd` dependencies:
+
+```
+$ sudo apt install \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libjpeg-dev \
+    libmicrohttpd-dev
+```
+
+Assumes you have [Bambu Studio] installed and ran at least once to download the
+expected plugins.
+
+```
+$ make -j
+```
+
+Use `PLUGIN_PATH` to specify a different path if the plugins are installed in a
+directory other than the default `~/.config/BambuStudio/plugins`.
+
+```
+$ make PLUGIN_PATH=/path/to/bambu/plugins -j
+```
+
+Use `DEBUG` to add more verbose logging and build debug symbols.
+
+```
+$ make DEBUG=1 -j
+```
+
+Use `BAMBU_FAKE` to use a fake camera implementation to test without an actual
+printer hardware. All device arguments are obviously ignored in this mode.
+
+```
+$ make BAMBU_FAKE=1 -j
+```
+
+Use `SERVER` to select the video streaming server implementation. More details
+below.
+
+```
+$ make SERVER=RTP -j
+```
+
+## HTTP Stream Details
+
+```
+$ make SERVER=HTTP -j
+```
+
+The HTTP server uses [`multipart/x-mixed-replace`] to continuous send JPEG files
+in a never-ending response.
+
+Build Bambu Cam with `SERVER=HTTP` and you can view the video stream on any web
+browser by navigating to `http://localhost:<port>/`.
+
+![Video stream example in a web browser](https://i.imgur.com/hvHuyc6.png])
+
+[`multipart/x-mixed-replace`]:https://wiki.tcl-lang.org/page/multipart%2Fx-mixed-replace
+
+## RTP Stream Details
+
+```
+$ make SERVER=RTP -j
+```
+
+The RTP stream uses the Pro-MPEG Code of Practice #3 Release 2 FEC protocol,
+which is "a 2D parity-check forward error correction mechanism for MPEG-2
+Transport Streams sent over RTP." Read more about the protocol in the [FFmpeg]
+and [Wireshark] documention.
+
+VLC supports this protocol and explains why we can use the `rtp://` path
+without serving any SDP nor RTSP information.
+
+Build Bambu Cam with `SERVER=RTP` and you can view the RTP stream in VLC:
+
+```
+$ vlc rtp://localhost/<port>
+```
+
+![Video stream example in VLC](https://i.imgur.com/lOo64MV.png)
+
+[Bambu Studio]:https://bambulab.com/en/download/studio
+[FFmpeg]:https://ffmpeg.org/ffmpeg-protocols.html#prompeg
+[Wireshark]:https://wiki.wireshark.org/2dParityFEC

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ services:
 ````
 
 ## Building the Image
-If you want to build the docker image for yourself, follow those steps:
+If you want to build the docker image by yourself, follow those steps:
 - clone this repo
 - create a folder "plugins"
 - put your "libBambuStudio.so" in there which is made available by Bambulab Software

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ flag. The supported video stream types are:
 - `HTTP`: Multipart JPEG stream using microhttpd
 - `RTP`: RTP video stream using FFmpeg
 
+## Docker Usage
+Use the following docker-compose.yaml to spawn a video-server:
+````yaml
+version: "3.8"
+
+services:
+  bambucam:
+    image: dockersilas/bambucam:1.0.0
+    container_name: bambucam
+
+    ports:
+      - "8082:8082" # the port number mapping where the video stream is serviced
+
+    environment: 
+    - DEVICE_ID="1A2B3C12345678" # your printer serial number (tho check for the right device)
+    - ACCESS_CODE="12345678" # your printer access code
+    - PORT=8082 # the port number where the video stream is serviced
+    - KEEP_ALIVE=true # true = run infinitly retrying if printer is offline, false = shutdown if printer offline
+    - PING_INTERVAL=10 # the interval (seconds) the printer is checked until available
+
+    restart: no
+````
+
 ## Build instructions
 
 Prepare the necessary `ffmpeg` and `libmicrohttpd` dependencies:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   bambucam:
-    image: DockerSilas/bambucam:1.0.0
+    image: dockersilas/bambucam:1.0.0
     container_name: bambucam
 
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,6 @@ services:
     env_file:
       - .env
 
-    restart: unless-stopped
+    restart: no
 
   

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.8"
+
+services:
+  bambucam:
+    image: DockerSilas/bambucam:1.0.0
+    container_name: bambucam
+
+    ports:
+      - "8082:8082" # the port number mapping where the video stream is serviced
+
+    env_file:
+      - .env
+
+    restart: unless-stopped
+
+  

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -e
+
+# ENV defaults
+DEVICE_IP="${DEVICE_IP}"
+DEVICE_ID="${DEVICE_ID}"
+ACCESS_CODE="${ACCESS_CODE}"
+PORT="${PORT}"
+KEEP_ALIVE="${KEEP_ALIVE}"   # true = bleibt an, false = Container exit bei Fehler
+PING_INTERVAL="${PING_INTERVAL}" # Sekunden zwischen Pings
+
+
+# Funktion zum Maskieren, nur letzte 2 Zeichen anzeigen
+# mask() {
+#     local val="$1"
+#     local len=${#val}
+#     if [ $len -le 2 ]; then
+#         echo "$val"
+#     else
+#         mask_len=$((len-2))
+#         masked=$(printf '%*s' "$mask_len" '' | tr ' ' '*')
+#         echo "${masked}${val: -2}"
+#     fi
+# }
+
+# Ausgabe aller ENV-Werte beim Start
+echo "=== STARTING bambucam container ==="
+echo "DEVICE_IP      = $DEVICE_IP"
+echo "DEVICE_ID      = $DEVICE_ID"
+echo "ACCESS_CODE    = $ACCESS_CODE"
+echo "PORT           = $PORT"
+echo "KEEP_ALIVE     = $KEEP_ALIVE"
+echo "PING_INTERVAL  = $PING_INTERVAL"
+echo "=================================="
+
+while true; do
+    # Prüfen, ob der Printer erreichbar ist
+    if nc -z -w2 "$DEVICE_IP" "6000"; then
+        echo "$(date '+%F %T') - printer available, starting bambucam"
+        # Bambucam starten und auf Exit warten
+        ./bambucam "$DEVICE_IP" "$DEVICE_ID" "$ACCESS_CODE" "$PORT" || true
+        EXIT_CODE=$?
+        echo "$(date '+%F %T') - bambucam exited with code $EXIT_CODE"
+    else
+        echo "$(date '+%F %T') - Printer not reachable (offline?)"
+        EXIT_CODE=1
+    fi
+
+    if [ "$KEEP_ALIVE" != "true" ]; then
+        echo "KEEP_ALIVE=false → Shutdown container"
+        exit $EXIT_CODE
+    fi
+
+    echo "Waiting $PING_INTERVAL seconds before retrying..."
+    sleep $PING_INTERVAL
+done


### PR DESCRIPTION
# Added Docker Support

By adding a Dockerfile, start-script and a compose, you can now easily setup bambucam as container running on a docker host. You simply have to configurate the settings of the Dockerfile/docker compose and can start the webserver.
Also i provided the Dockerfile build instructions if you want to build the image for yourself.

## Changes
- Added .gitignore to ignore env-variables in file and the bambulib
- Added the dockerfile to build the bambucam image
- Added a start.sh called by the image which contains a loop for starting the stream if its ready
- Added a docker-compose for easy deployment
- Updated the README with the new docker instructions